### PR TITLE
Creation of user via POST request

### DIFF
--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -4,6 +4,6 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("exchange-rates/", include("exchange_rates.urls")),
-    path("", include("core.urls")),
     path("users/", include("users.urls")),
+    path("", include("core.urls")),
 ]

--- a/src/users/serializers.py
+++ b/src/users/serializers.py
@@ -1,15 +1,17 @@
 from django.contrib.auth import get_user_model
-from django.contrib.auth.hashers import make_password
 from rest_framework import serializers
 
 User = get_user_model()
 
 
-class UserRegistrationSerializer(serializers.ModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ["email", "password"]
+        extra_kwargs = {"password": {"write_only": True}}
 
-    def validate(self, attrs):
-        attrs["password"] = make_password(attrs["password"])
-        return attrs
+    def create(self, validated_data):
+        user = User(**validated_data)
+        user.set_password(validated_data["password"])
+        user.save()
+        return user

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -2,13 +2,13 @@ from django.contrib.auth import get_user_model
 from django.urls import path
 from rest_framework.generics import CreateAPIView
 
-from users.serializers import UserRegistrationSerializer
+from users.serializers import UserSerializer
 
 User = get_user_model()
 
 
 class UserCreateAPI(CreateAPIView):
-    serializer_class = UserRegistrationSerializer
+    serializer_class = UserSerializer
 
 
 urlpatterns = [


### PR DESCRIPTION
The user registration endpoint was updated:
- User can be created by using the HTTP POST /users
- The rest_framework.CreateAPIView was used as a request handler
- The save() was handled by the UserSerializer
- The password field was excluded from the user create response