### PR TITLE
Permissions

### DIFF
--- a/src/tickets/api.py
+++ b/src/tickets/api.py
@@ -24,7 +24,7 @@ class TicketAPISet(ModelViewSet):
         elif self.action == "retrieve":
             permission_classes = [IsOwner | RoleIsAdmin | IsManagerProcessing]
         elif self.action == "update":
-            permission_classes = [RoleIsAdmin | RoleIsManager]
+            permission_classes = [RoleIsAdmin | IsManagerProcessing]
         elif self.action == "destroy":
             permission_classes = [RoleIsAdmin, IsManagerProcessing]
         else:

--- a/src/tickets/api.py
+++ b/src/tickets/api.py
@@ -26,7 +26,7 @@ class TicketAPISet(ModelViewSet):
         elif self.action == "update":
             permission_classes = [RoleIsAdmin | IsManagerProcessing]
         elif self.action == "destroy":
-            permission_classes = [RoleIsAdmin, IsManagerProcessing]
+            permission_classes = [IsOwner, RoleIsAdmin, IsManagerProcessing]
         else:
             permission_classes = []
 

--- a/src/tickets/permissions.py
+++ b/src/tickets/permissions.py
@@ -22,6 +22,14 @@ class IsOwner(BasePermission):
         return obj.customer == request.user
 
 
+class IsManagerProcessing(BasePermission):
+    def has_permission(self, request, view):
+        return True
+
+    def has_object_permission(self, request, view, obj: Ticket):
+        return obj.manager == request.user
+
+
 class RoleIsUser(BasePermission):
     def has_permission(self, request, view):
         return request.user.role == Role.USER


### PR DESCRIPTION
Tickets CRUD API is completed
/tickets/ permissions are adjusted:
- create only for users
- list only for admins and managers
- retrieve only for users (who are customers) or managers (of that specific ticket), or admin
- update only for users who are managers of that specific ticket, or admin
- delete only for users (who are owners of a specific ticket), manager of that specific ticket, or admin